### PR TITLE
dpkg: Browse dependencies with Helm

### DIFF
--- a/helm-system-packages-dpkg.el
+++ b/helm-system-packages-dpkg.el
@@ -62,30 +62,31 @@ Requirements:
 (defun helm-system-packages-dpkg-run-as-root (command &rest args)
   "COMMAND to run over `helm-marked-candidates'.
 
-COMMAND will be run in a term-mode buffer `helm-system-packages-dpkg-term-buffer'.
-Eshell cannot be used for dpkg because of its \"configure\" mecanism which uses
-a curses interface."
+COMMAND will be run in a term-mode buffer
+`helm-system-packages-dpkg-term-buffer'.  Eshell cannot be used
+for dpkg because of its \"configure\" mecanism which uses a
+curses interface."
   (let ((arg-list (append args (helm-marked-candidates))))
     ;; Refresh package list after command has completed.
     (push command arg-list)
     (push "sudo" arg-list)
-  (if (and helm-system-packages-dpkg-term-buffer
-           (buffer-live-p (get-buffer helm-system-packages-dpkg-term-buffer)))
-      (switch-to-buffer helm-system-packages-dpkg-term-buffer)
-    (ansi-term (getenv "SHELL") "term dpkg")
-    (setq helm-system-packages-dpkg-term-buffer (buffer-name))
-    (term-line-mode))
-  (goto-char (process-mark (get-buffer-process (current-buffer))))
-  ;; TODO: Detect if an existing process is still running.
-  (delete-region (point) (point-max))
-  (insert (mapconcat 'identity arg-list " "))
-  (term-char-mode)
-  ;; It seems that it's not possible to add a post-command hook with "term".
-  ;; Let's reset the cache right-away then.
-  (setq helm-system-packages-dpkg--names nil
-        helm-system-packages-dpkg--descriptions nil)
-  (when helm-system-packages-auto-send-commandline-p
-    (term-send-input))))
+    (if (and helm-system-packages-dpkg-term-buffer
+             (buffer-live-p (get-buffer helm-system-packages-dpkg-term-buffer)))
+        (switch-to-buffer helm-system-packages-dpkg-term-buffer)
+      (ansi-term (getenv "SHELL") "term dpkg")
+      (setq helm-system-packages-dpkg-term-buffer (buffer-name))
+      (term-line-mode))
+    (goto-char (process-mark (get-buffer-process (current-buffer))))
+    ;; TODO: Detect if an existing process is still running.
+    (delete-region (point) (point-max))
+    (insert (mapconcat 'identity arg-list " "))
+    (term-char-mode)
+    ;; It seems that it's not possible to add a post-command hook with "term".
+    ;; Let's reset the cache right-away then.
+    (setq helm-system-packages-dpkg--names nil
+          helm-system-packages-dpkg--descriptions nil)
+    (when helm-system-packages-auto-send-commandline-p
+      (term-send-input))))
 
 (defvar helm-system-packages-dpkg-map
   (let ((map (make-sparse-keymap)))
@@ -105,52 +106,64 @@ a curses interface."
 (defun helm-system-packages-dpkg-toggle-explicit ()
   (interactive)
   (with-helm-alive-p
-    (setq helm-system-packages-dpkg--show-explicit-p (not helm-system-packages-dpkg--show-explicit-p))
+    (setq helm-system-packages-dpkg--show-explicit-p
+          (not helm-system-packages-dpkg--show-explicit-p))
     (helm-update)))
 (put 'helm-system-packages-dpkg-toggle-explicit 'helm-only t)
 
 (defun helm-system-packages-dpkg-toggle-uninstalled ()
   (interactive)
   (with-helm-alive-p
-    (setq helm-system-packages-dpkg--show-uninstalled-p (not helm-system-packages-dpkg--show-uninstalled-p))
+    (setq helm-system-packages-dpkg--show-uninstalled-p
+          (not helm-system-packages-dpkg--show-uninstalled-p))
     (helm-update)))
 (put 'helm-system-packages-dpkg-toggle-uninstalled 'helm-only t)
 
 (defun helm-system-packages-dpkg-toggle-dependencies ()
   (interactive)
   (with-helm-alive-p
-    (setq helm-system-packages-dpkg--show-dependencies-p (not helm-system-packages-dpkg--show-dependencies-p))
+    (setq helm-system-packages-dpkg--show-dependencies-p
+          (not helm-system-packages-dpkg--show-dependencies-p))
     (helm-update)))
 (put 'helm-system-packages-dpkg-toggle-dependencies 'helm-only t)
 
 (defun helm-system-packages-dpkg-toggle-residuals ()
   (interactive)
   (with-helm-alive-p
-    (setq helm-system-packages-dpkg--show-residuals-p (not helm-system-packages-dpkg--show-residuals-p))
+    (setq helm-system-packages-dpkg--show-residuals-p
+          (not helm-system-packages-dpkg--show-residuals-p))
     (helm-update)))
 (put 'helm-system-packages-dpkg-toggle-residuals 'helm-only t)
 
 (defun helm-system-packages-dpkg-transformer (packages)
   (let (res (pkglist (reverse packages)))
     (dolist (p pkglist res)
-      (let ((face (cdr (assoc (helm-system-packages-extract-name p) helm-system-packages--display-lists))))
+      (let ((face (cdr (assoc (helm-system-packages-extract-name p)
+                              helm-system-packages--display-lists))))
         (cond
-         ((not face) (when helm-system-packages-dpkg--show-uninstalled-p (push p res)))
+         ((not face) (when helm-system-packages-dpkg--show-uninstalled-p
+                       (push p res)))
          ((or
-           (and helm-system-packages-dpkg--show-explicit-p (memq 'helm-system-packages-dpkg-explicit face))
-           (and helm-system-packages-dpkg--show-dependencies-p (memq 'helm-system-packages-dpkg-dependencies face))
-           (and helm-system-packages-dpkg--show-residuals-p (memq 'helm-system-packages-dpkg-residuals face)))
+           (and helm-system-packages-dpkg--show-explicit-p
+                (memq 'helm-system-packages-dpkg-explicit face))
+           (and helm-system-packages-dpkg--show-dependencies-p
+                (memq 'helm-system-packages-dpkg-dependencies face))
+           (and helm-system-packages-dpkg--show-residuals-p
+                (memq 'helm-system-packages-dpkg-residuals face)))
           (push (propertize p 'face (car face)) res)))))))
 
-(defface helm-system-packages-dpkg-explicit '((t (:inherit font-lock-warning-face)))
+(defface helm-system-packages-dpkg-explicit
+  '((t (:inherit font-lock-warning-face)))
   "Face for explicitly installed packages."
   :group 'helm-system-packages)
 
-(defface helm-system-packages-dpkg-dependencies '((t (:inherit font-lock-comment-face :slant italic)))
+(defface helm-system-packages-dpkg-dependencies
+  '((t (:inherit font-lock-comment-face :slant italic)))
   "Face for packages installed as dependencies."
   :group 'helm-system-packages)
 
-(defface helm-system-packages-dpkg-residuals '((t (:inherit font-lock-string-face :slant italic)))
+(defface helm-system-packages-dpkg-residuals
+  '((t (:inherit font-lock-string-face :slant italic)))
   "Face for packages with left-over configuration files."
   :group 'helm-system-packages)
 
@@ -170,10 +183,11 @@ a curses interface."
   "List packages with left-over configuration files."
   (let (res)
     (dolist (pkgline
-             (split-string (with-temp-buffer
-                                     (call-process "dpkg" nil t nil "--get-selections")
-                                     (buffer-string))
-                                   "\n")
+             (split-string
+              (with-temp-buffer
+                (call-process "dpkg" nil t nil "--get-selections")
+                (buffer-string))
+              "\n")
              res)
       (let ((pkg (split-string pkgline)))
         (when (string= (cadr pkg) "deinstall")
@@ -195,7 +209,8 @@ a curses interface."
   (with-temp-buffer
     ;; `apt-cache search` is much faster than `apt-cache show`.
     (call-process "apt-cache" nil '(t nil) nil "search" ".")
-    ;; apt-cache's output format is "pkg - desc".  Remove "-" and align to column.
+    ;; apt-cache's output format is "pkg - desc".  Remove "-" and align to
+    ;; column.
     (goto-char (point-min))
     (while (search-forward " " nil t)
       (delete-char 1)
@@ -227,11 +242,14 @@ a curses interface."
         (residuals (helm-system-packages-dpkg-list-residuals)))
     (setq helm-system-packages--display-lists nil)
     (dolist (p explicit)
-      (push (cons p '(helm-system-packages-dpkg-explicit)) helm-system-packages--display-lists))
+      (push (cons p '(helm-system-packages-dpkg-explicit))
+            helm-system-packages--display-lists))
     (dolist (p dependencies)
-      (push (cons p '(helm-system-packages-dpkg-dependencies)) helm-system-packages--display-lists))
+      (push (cons p '(helm-system-packages-dpkg-dependencies))
+            helm-system-packages--display-lists))
     (dolist (p residuals)
-      (push (cons p '(helm-system-packages-dpkg-residuals)) helm-system-packages--display-lists))))
+      (push (cons p '(helm-system-packages-dpkg-residuals))
+            helm-system-packages--display-lists))))
 
 (defun helm-system-packages-dpkg-print-url (_)
   "Print homepage URLs of `helm-marked-candidates'.
@@ -259,11 +277,18 @@ Used to restore complete name list when browsing dependencies.")
 With prefix argument, insert the output at point.
 
 If REVERSE is non-nil, show reverse dependencies instead."
-  (setq helm-system-packages-dpkg--descriptions (or helm-system-packages-dpkg--descriptions-global helm-system-packages-dpkg--descriptions)
-        helm-system-packages-dpkg--descriptions-global helm-system-packages-dpkg--descriptions)
-  (setq helm-system-packages-dpkg--names (or helm-system-packages-dpkg--names-global helm-system-packages-dpkg--names)
-        helm-system-packages-dpkg--names-global helm-system-packages-dpkg--names)
-  (let ((res (apply #'helm-system-packages-run "apt-cache" (if reverse "rdepends" "depends")))
+  (setq helm-system-packages-dpkg--descriptions
+        (or helm-system-packages-dpkg--descriptions-global
+            helm-system-packages-dpkg--descriptions))
+  (setq helm-system-packages-dpkg--descriptions-global
+        helm-system-packages-dpkg--descriptions)
+  (setq helm-system-packages-dpkg--names
+        (or helm-system-packages-dpkg--names-global
+            helm-system-packages-dpkg--names))
+  (setq helm-system-packages-dpkg--names-global
+        helm-system-packages-dpkg--names)
+  (let ((res (apply #'helm-system-packages-run "apt-cache"
+                    (if reverse "rdepends" "depends")))
         desc-res)
     (if (string= res "")
         (message "No dependencies")
@@ -273,14 +298,17 @@ If REVERSE is non-nil, show reverse dependencies instead."
                   (delete-duplicate-lines (point-min) (point-max))
                   (buffer-string)))
       (dolist (name (split-string res "\n" t))
-        (when (string-match (concat "^" name "  .*$") helm-system-packages-dpkg--descriptions)
-          (setq desc-res (concat desc-res (match-string 0 helm-system-packages-dpkg--descriptions) "\n"))))
+        (when (string-match (concat "^" name "  .*$")
+                            helm-system-packages-dpkg--descriptions)
+          (setq desc-res
+                (concat desc-res
+                        (match-string 0 helm-system-packages-dpkg--descriptions) "\n"))))
       (let ((helm-system-packages-dpkg--descriptions desc-res)
             (helm-system-packages-dpkg--names res)
-            (helm-system-packages-dpkg--source-name (concat
-                                                     (if reverse "Reverse deps" "Deps")
-                                                     " of "
-                                                     (mapconcat 'identity (helm-marked-candidates) " "))))
+            (helm-system-packages-dpkg--source-name
+             (concat (if reverse "Reverse deps" "Deps")
+                     " of "
+                     (mapconcat 'identity (helm-marked-candidates) " "))))
         (helm-system-packages-dpkg)))))
 
 (defcustom helm-system-packages-dpkg-actions
@@ -289,10 +317,12 @@ If REVERSE is non-nil, show reverse dependencies instead."
        (helm-system-packages-print "apt-cache" "show")))
     ("Install (`C-u' to reinstall)" .
      (lambda (_)
-       (helm-system-packages-dpkg-run-as-root "apt-get" "install" (when helm-current-prefix-arg "--reinstall") )))
+       (helm-system-packages-dpkg-run-as-root
+        "apt-get" "install" (when helm-current-prefix-arg "--reinstall"))))
     ("Uninstall (`C-u' to include dependencies)" .
      (lambda (_)
-       (helm-system-packages-dpkg-run-as-root "apt-get" "remove" (when helm-current-prefix-arg "--auto-remove"))))
+       (helm-system-packages-dpkg-run-as-root
+        "apt-get" "remove" (when helm-current-prefix-arg "--auto-remove"))))
     ("Browse homepage URL" . helm-system-packages-dpkg-print-url)
     ("Find files" .
      (lambda (_)
@@ -305,7 +335,8 @@ If REVERSE is non-nil, show reverse dependencies instead."
        (helm-system-packages-print "apt-cache" "rdepends")))
     ("Uninstall/Purge (`C-u' to include dependencies)" .
      (lambda (_)
-       (helm-system-packages-dpkg-run-as-root "apt-get" "purge" (when helm-current-prefix-arg "--auto-remove")))))
+       (helm-system-packages-dpkg-run-as-root
+        "apt-get" "purge" (when helm-current-prefix-arg "--auto-remove")))))
   "Actions for Helm dpkg."
   :group 'helm-system-packages
   :type '(alist :key-type string :value-type function))


### PR DESCRIPTION
@thierryvolpiatto : Can you test this?

It runs helm-system-packages-dpkg recursively on the (reverse) dependencies of the selected package(s).
For instance, if `foo` depends on `bar` and `baz`, then showing dependencies will re-run the session with only `bar` and `baz` in the list.
In turn, the (reverse) dependencies of those packages can be queried the same way.

Can you check the following in particular:

- That dependencies of non-installed packages also work.
- What happens on unknown packages.

Does `dpkg` know the concept of _virtual_ packages?

For instance, the 3D-oriented packages might depend on `libgl` which is a virtual package satisfied by `mesa` or `nvidia`.
In that case, Helm will fail to find the virtual package because it does not exist.  I've taken provisions for `pacman`, but I'm not sure how it works for `dpkg`.
