### PR TITLE
[WIP] Add tramp support

### DIFF
--- a/helm-system-packages-dpkg.el
+++ b/helm-system-packages-dpkg.el
@@ -139,13 +139,13 @@ Requirements:
 (defun helm-system-packages-dpkg-list-explicit ()
   "List explicitly installed packages."
   (split-string (with-temp-buffer
-                  (call-process "apt-mark" nil t nil "showmanual")
+                  (process-file "apt-mark" nil t nil "showmanual")
                   (buffer-string))))
 
 (defun helm-system-packages-dpkg-list-dependencies ()
   "List packages installed as a dependency."
   (split-string (with-temp-buffer
-                  (call-process "apt-mark" nil t nil "showauto")
+                  (process-file "apt-mark" nil t nil "showauto")
                   (buffer-string))))
 
 (defun helm-system-packages-dpkg-list-residuals ()
@@ -154,7 +154,7 @@ Requirements:
     (dolist (pkgline
              (split-string
               (with-temp-buffer
-                (call-process "dpkg" nil t nil "--get-selections")
+                (process-file "dpkg" nil t nil "--get-selections")
                 (buffer-string))
               "\n")
              res)
@@ -165,7 +165,7 @@ Requirements:
 (defun helm-system-packages-dpkg-cache-names () ; TODO: Build from --descriptions instead like pacman?
   "Cache all package names."
   (with-temp-buffer
-    (call-process "apt-cache" nil t nil "pkgnames")
+    (process-file "apt-cache" nil t nil "pkgnames")
     ;; (sort-lines nil (point-min) (point-max))
     (buffer-string)))
 
@@ -178,7 +178,7 @@ Requirements:
   "Cache all package names with descriptions."
   (with-temp-buffer
     ;; `apt-cache search` is much faster than `apt-cache show`.
-    (call-process "apt-cache" nil '(t nil) nil "search" ".")
+    (process-file "apt-cache" nil '(t nil) nil "search" ".")
     ;; apt-cache's output format is "pkg - desc".  Remove "-" and align to
     ;; column.
     (goto-char (point-min))

--- a/helm-system-packages-pacman.el
+++ b/helm-system-packages-pacman.el
@@ -153,26 +153,26 @@ This is only used for dependency display.")
 (defun helm-system-packages-pacman-list-explicit ()
   "List explicitly installed packages."
   (split-string (with-temp-buffer
-                  (call-process "pacman" nil t nil "--query" "--explicit" "--quiet")
+                  (process-file "pacman" nil t nil "--query" "--explicit" "--quiet")
                   (buffer-string))))
 
 (defun helm-system-packages-pacman-list-dependencies ()
   "List packages installed as a required dependency."
   (split-string (with-temp-buffer
-                  (call-process "pacman" nil t nil "--query" "--deps" "--quiet")
+                  (process-file "pacman" nil t nil "--query" "--deps" "--quiet")
                   (buffer-string))))
 
 (defun helm-system-packages-pacman-list-orphans ()
   "List orphan packages (unrequired dependencies)."
   (split-string (with-temp-buffer
-                  (call-process "pacman" nil t nil "--query" "--deps" "--unrequired" "--quiet")
+                  (process-file "pacman" nil t nil "--query" "--deps" "--unrequired" "--quiet")
                   (buffer-string))))
 
 (defun helm-system-packages-pacman-list-locals ()
   "List explicitly installed local packages.
 Local packages can also be orphans, explicit or dependencies."
   (split-string (with-temp-buffer
-                  (call-process "pacman" nil t nil "--query" "--foreign" "--quiet")
+                  (process-file "pacman" nil t nil "--query" "--foreign" "--quiet")
                   (buffer-string))))
 
 (defcustom helm-system-packages-pacman-column-width 40
@@ -191,8 +191,8 @@ Return (NAMES . DESCRIPTIONS), a cons of two strings."
           (with-temp-buffer
             ;; TODO: Possible optimization: Output directly in Elisp?
             (let ((format-string (format "%%-%dn  %%d" helm-system-packages-pacman-column-width)))
-              (call-process "expac" nil '(t nil) nil "--sync" format-string)
-              (apply 'call-process "expac" nil '(t nil) nil "--query" format-string local-packages))
+              (process-file "expac" nil '(t nil) nil "--sync" format-string)
+              (apply 'process-file "expac" nil '(t nil) nil "--query" format-string local-packages))
             (sort-lines nil (point-min) (point-max))
             (buffer-string)))
     ;; replace-regexp-in-string is faster than mapconcat over split-string.
@@ -261,11 +261,11 @@ Return (\"local-command-result\" . \"sync-command-result\")."
        (with-temp-buffer
          (when local
            ;; We discard errors.
-           (apply #'call-process (caar commands) nil t nil (append (cdar commands) local))
+           (apply #'process-file (caar commands) nil t nil (append (cdar commands) local))
            (buffer-string)))
        (with-temp-buffer
          (when sync
-           (apply #'call-process (cadr commands) nil t nil (append (cddr commands) sync))
+           (apply #'process-file (cadr commands) nil t nil (append (cddr commands) sync))
            (buffer-string)))))))
 
 (defun helm-system-packages-pacman-info (_candidate)

--- a/helm-system-packages-portage.el
+++ b/helm-system-packages-portage.el
@@ -114,14 +114,14 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
     (setq explicit (helm-system-packages-portage-list-explicit)))
   (seq-difference
    (split-string (with-temp-buffer
-                   (call-process "qlist" nil t nil "-I")
+                   (process-file "qlist" nil t nil "-I")
                    (buffer-string)))
    explicit))
 
 (defun helm-system-packages-portage-cache-names ()
   "Cache all package names."
   (with-temp-buffer
-    (call-process "eix" nil t nil "--only-names")
+    (process-file "eix" nil t nil "--only-names")
     (buffer-string)))
 
 (defcustom helm-system-packages-portage-column-width 36
@@ -137,7 +137,7 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
     ;; re-use its code.
     ;; TODO: Can eix pad in the format string just like `expac' does?
     ;; TODO: Or output straight to Elisp?
-    (call-process "env" nil '(t nil) nil "EIX_LIMIT=0" "OVERLAYS_LIST=none" "PRINT_COUNT_ALWAYS=never" "eix" "--format" "<category>/<name> - <description>\n")
+    (process-file "env" nil '(t nil) nil "EIX_LIMIT=0" "OVERLAYS_LIST=none" "PRINT_COUNT_ALWAYS=never" "eix" "--format" "<category>/<name> - <description>\n")
     (goto-char (point-min))
     (while (search-forward " " nil t)
       (delete-char 1)
@@ -232,7 +232,7 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
     (helm-init-candidates-in-buffer
         'global
       (with-temp-buffer
-        (call-process "eix" nil t nil "--print-all-useflags")
+        (process-file "eix" nil t nil "--print-all-useflags")
         (buffer-string)))))
 
 (defcustom helm-system-packages-portage-use-actions
@@ -240,7 +240,7 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
      (lambda (elm)
        (switch-to-buffer helm-system-packages-buffer)
        (erase-buffer)
-       (apply #'call-process "euse" nil t nil `("--info" ,elm))
+       (apply #'process-file "euse" nil t nil `("--info" ,elm))
        (font-lock-add-keywords nil `((,elm . font-lock-variable-name-face)))
        (font-lock-mode 1)))
     ("Enable" .
@@ -269,7 +269,7 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
 (defun helm-system-packages-portage-use-transformer (use-flags)
   "Highlight enabled USE flags."
   (let ((local-uses (split-string (with-temp-buffer
-                                    (call-process "portageq" nil t nil "envvar" "USE")
+                                    (process-file "portageq" nil t nil "envvar" "USE")
                                     (buffer-string)))))
     (mapcar (lambda (use-flag)
               (propertize use-flag 'face

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -105,7 +105,7 @@ such as the package description."
   (let ((arg-list (append args (helm-marked-candidates))))
     (with-temp-buffer
       ;; We discard errors.
-      (apply #'call-process command nil t nil arg-list)
+      (apply #'process-file command nil t nil arg-list)
       (buffer-string))))
 
 (defun helm-system-packages-print (command &rest args)


### PR DESCRIPTION
The first step for working with remote hosts is to replace all call-process with process-file. Now one can run `M-x helm-system-packages` from a remote buffer or a remote dired directory and receive packages from this remote host. Install/uninstall works fine, since eshell supports tramp. I tested only for dpkg, before merging should be tested for all other managers, I suppose. 
There are few problems left, however:
- [ ] We should reset caches, when invoking `M-x helm-system-packages` from different host. I think we can store the last accessed host in a new variable and if its value doesn't match with the current host, we will reset all caches.
- [ ] We should open new eshell sessions for remote hosts. I think, it is possible to get a list of opened eshells and check hosts of each eshell. If there is no matching eshell, we just create new one.
- [ ] helm-packages-file does not work well with remote hosts. It try to open local files, instead of remote. Don't know how to fix this for now.  

Before I continue, I wanted to be sure, that you are interested in supporting tramp in this package. 