### PR TITLE
Tramp support [Testing]

### DIFF
--- a/helm-system-packages-dpkg.el
+++ b/helm-system-packages-dpkg.el
@@ -139,13 +139,13 @@ Requirements:
 (defun helm-system-packages-dpkg-list-explicit ()
   "List explicitly installed packages."
   (split-string (with-temp-buffer
-                  (call-process "apt-mark" nil t nil "showmanual")
+                  (process-file "apt-mark" nil t nil "showmanual")
                   (buffer-string))))
 
 (defun helm-system-packages-dpkg-list-dependencies ()
   "List packages installed as a dependency."
   (split-string (with-temp-buffer
-                  (call-process "apt-mark" nil t nil "showauto")
+                  (process-file "apt-mark" nil t nil "showauto")
                   (buffer-string))))
 
 (defun helm-system-packages-dpkg-list-residuals ()
@@ -154,7 +154,7 @@ Requirements:
     (dolist (pkgline
              (split-string
               (with-temp-buffer
-                (call-process "dpkg" nil t nil "--get-selections")
+                (process-file "dpkg" nil t nil "--get-selections")
                 (buffer-string))
               "\n")
              res)
@@ -165,7 +165,7 @@ Requirements:
 (defun helm-system-packages-dpkg-cache-names () ; TODO: Build from --descriptions instead like pacman?
   "Cache all package names."
   (with-temp-buffer
-    (call-process "apt-cache" nil t nil "pkgnames")
+    (process-file "apt-cache" nil t nil "pkgnames")
     ;; (sort-lines nil (point-min) (point-max))
     (buffer-string)))
 
@@ -178,7 +178,7 @@ Requirements:
   "Cache all package names with descriptions."
   (with-temp-buffer
     ;; `apt-cache search` is much faster than `apt-cache show`.
-    (call-process "apt-cache" nil '(t nil) nil "search" ".")
+    (process-file "apt-cache" nil '(t nil) nil "search" ".")
     ;; apt-cache's output format is "pkg - desc".  Remove "-" and align to
     ;; column.
     (goto-char (point-min))

--- a/helm-system-packages-dpkg.el
+++ b/helm-system-packages-dpkg.el
@@ -215,15 +215,14 @@ Requirements:
 
 (defun helm-system-packages-dpkg-info (_candidate)
   "Print information about the selected packages.
-
 With prefix argument, insert the output at point.
 Otherwise display in `helm-system-packages-buffer'."
   (helm-system-packages-show-information
    ;; TODO: Optimize by calling the command only once and parsing output.
-   '((uninstalled ,(mapcar (lambda (pkg)
-                             (cons pkg
-                                   (helm-system-packages-call "apt-cache" nil "show" pkg)))
-                           (helm-marked-candidates))))))
+   `((uninstalled . ,(mapcar (lambda (pkg)
+                               (cons pkg
+                                     (helm-system-packages-call "apt-cache" nil "show" pkg)))
+                             (helm-marked-candidates))))))
 
 (defun helm-system-packages-dpkg-browse-url (_)
   "Print homepage URLs of `helm-marked-candidates'.

--- a/helm-system-packages-dpkg.el
+++ b/helm-system-packages-dpkg.el
@@ -285,12 +285,6 @@ If REVERSE is non-nil, list reverse dependencies instead."
     ("Show reverse dependencies" .
      (lambda (_)
        (helm-system-packages-dpkg-show-dependencies _ 'reverse)))
-    ("Show dependencies" .
-     (lambda (_)
-       (helm-system-packages-print "apt-cache" "depends")))
-    ("Show reverse dependencies" .
-     (lambda (_)
-       (helm-system-packages-print "apt-cache" "rdepends")))
     ("Uninstall/Purge (`C-u' to include dependencies)" .
      (lambda (_)
        (apply 'helm-system-packages-run-as-root-over-installed

--- a/helm-system-packages-pacman.el
+++ b/helm-system-packages-pacman.el
@@ -246,7 +246,7 @@ tested package to fall back on."
 (defun helm-system-packages-pacman-install (_)
   "Install marked candidates."
   (when helm-system-packages-pacman-auto-clean-cache
-    (let ((eshell-buffer-name helm-system-packages-eshell-buffer)) ; TODO: Use same as in main.
+    (let ((eshell-buffer-name (helm-system-packages-shell-name)))
       (eshell)
       (unless (eshell-interactive-process)
         (goto-char (point-max))

--- a/helm-system-packages-pacman.el
+++ b/helm-system-packages-pacman.el
@@ -147,7 +147,7 @@ LOCAL-PACKAGES and GROUPS are lists of strings."
 
 (defcustom helm-system-packages-pacman-column-width 40
   "Column at which descriptions are aligned, excluding a double-space gap.
-If nil, then use `helm-system-package-column-width'."
+If nil, then use `helm-system-packages-column-width'."
   :group 'helm-system-packages
   :type 'integer)
 

--- a/helm-system-packages-pacman.el
+++ b/helm-system-packages-pacman.el
@@ -222,9 +222,9 @@ Otherwise display in `helm-system-packages-buffer'."
                        (string-match ".*: \\(.*\\)" desc)
                        (cons (match-string 1 desc) (substring desc (match-end 2))))
                      (split-string info-string "\n\n" t)))))
-    (helm-system-packages-mapalist '((uninstalled (lambda (packages) (helm-system-packages-call "pacman" packages "--sync" "--info" "--info")))
+    (helm-system-packages-mapalist '((uninstalled (lambda (packages) (helm-system-packages-call "pacman" packages "--sync" "--info" "--info" "--color" "never")))
                                      (groups ignore)
-                                     (all (lambda (packages) (helm-system-packages-call "pacman" packages "--query" "--info" "--info"))))
+                                     (all (lambda (packages) (helm-system-packages-call "pacman" packages "--query" "--info" "--info" "--color" "never"))))
                                    (helm-system-packages-categorize (helm-marked-candidates))))))
 
 (defcustom helm-system-packages-pacman-auto-clean-cache nil

--- a/helm-system-packages-pacman.el
+++ b/helm-system-packages-pacman.el
@@ -280,10 +280,10 @@ exact same information."
                                        ;; Prepend the missing leading '/' to pacman's file database queries.'
                                        (replace-regexp-in-string
                                         "\\([^ ]+ \\)" "\\1/"
-                                        (helm-system-packages-call "pacman" packages "--files" "--list"))))
+                                        (helm-system-packages-call "pacman" packages "--files" "--list" "--color" "never"))))
                         (groups ignore)
                         (all (lambda (packages)
-                               (helm-system-packages-call "pacman" packages "--query" "--list"))))
+                               (helm-system-packages-call "pacman" packages "--query" "--list" "--color" "never"))))
                       (helm-system-packages-categorize (helm-marked-candidates)))))
       ;; The first word of the line (package name) is the hash table key,
       ;; the rest is pushed to the value (list of files).

--- a/helm-system-packages-pacman.el
+++ b/helm-system-packages-pacman.el
@@ -29,6 +29,10 @@
 (require 'helm)
 (require 'helm-system-packages)
 
+;; Shut up byte compiler
+(declare-function eshell-interactive-process "esh-cmd.el")
+(defvar eshell-buffer-name)
+
 (defvar helm-system-packages-pacman-help-message
   "* Helm pacman
 

--- a/helm-system-packages-pacman.el
+++ b/helm-system-packages-pacman.el
@@ -153,26 +153,26 @@ This is only used for dependency display.")
 (defun helm-system-packages-pacman-list-explicit ()
   "List explicitly installed packages."
   (split-string (with-temp-buffer
-                  (call-process "pacman" nil t nil "--query" "--explicit" "--quiet")
+                  (process-file "pacman" nil t nil "--query" "--explicit" "--quiet")
                   (buffer-string))))
 
 (defun helm-system-packages-pacman-list-dependencies ()
   "List packages installed as a required dependency."
   (split-string (with-temp-buffer
-                  (call-process "pacman" nil t nil "--query" "--deps" "--quiet")
+                  (process-file "pacman" nil t nil "--query" "--deps" "--quiet")
                   (buffer-string))))
 
 (defun helm-system-packages-pacman-list-orphans ()
   "List orphan packages (unrequired dependencies)."
   (split-string (with-temp-buffer
-                  (call-process "pacman" nil t nil "--query" "--deps" "--unrequired" "--quiet")
+                  (process-file "pacman" nil t nil "--query" "--deps" "--unrequired" "--quiet")
                   (buffer-string))))
 
 (defun helm-system-packages-pacman-list-locals ()
   "List explicitly installed local packages.
 Local packages can also be orphans, explicit or dependencies."
   (split-string (with-temp-buffer
-                  (call-process "pacman" nil t nil "--query" "--foreign" "--quiet")
+                  (process-file "pacman" nil t nil "--query" "--foreign" "--quiet")
                   (buffer-string))))
 
 (defcustom helm-system-packages-pacman-column-width 40
@@ -191,8 +191,8 @@ Return (NAMES . DESCRIPTIONS), a cons of two strings."
           (with-temp-buffer
             ;; TODO: Possible optimization: Output directly in Elisp?
             (let ((format-string (format "%%-%dn  %%d" helm-system-packages-pacman-column-width)))
-              (call-process "expac" nil '(t nil) nil "--sync" format-string)
-              (apply 'call-process "expac" nil '(t nil) nil "--query" format-string local-packages))
+              (process-file "expac" nil '(t nil) nil "--sync" format-string)
+              (apply 'process-file "expac" nil '(t nil) nil "--query" format-string local-packages))
             (sort-lines nil (point-min) (point-max))
             (buffer-string)))
     ;; replace-regexp-in-string is faster than mapconcat over split-string.
@@ -261,11 +261,11 @@ Return (\"local-command-result\" . \"sync-command-result\")."
        (with-temp-buffer
          (when local
            ;; We discard errors.
-           (apply #'call-process (caar commands) nil t nil (append (cdar commands) local))
+           (apply #'process-file (caar commands) nil t nil (append (cdar commands) local))
            (buffer-string)))
        (with-temp-buffer
          (when sync
-           (apply #'call-process (cadr commands) nil t nil (append (cddr commands) sync))
+           (apply #'process-file (cadr commands) nil t nil (append (cddr commands) sync))
            (buffer-string)))))))
 
 (defun helm-system-packages-pacman-info (_candidate)

--- a/helm-system-packages-portage.el
+++ b/helm-system-packages-portage.el
@@ -114,14 +114,14 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
     (setq explicit (helm-system-packages-portage-list-explicit)))
   (seq-difference
    (split-string (with-temp-buffer
-                   (call-process "qlist" nil t nil "-I")
+                   (process-file "qlist" nil t nil "-I")
                    (buffer-string)))
    explicit))
 
 (defun helm-system-packages-portage-cache-names ()
   "Cache all package names."
   (with-temp-buffer
-    (call-process "eix" nil t nil "--only-names")
+    (process-file "eix" nil t nil "--only-names")
     (buffer-string)))
 
 (defcustom helm-system-packages-portage-column-width 36
@@ -137,7 +137,7 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
     ;; re-use its code.
     ;; TODO: Can eix pad in the format string just like `expac' does?
     ;; TODO: Or output straight to Elisp?
-    (call-process "env" nil '(t nil) nil "EIX_LIMIT=0" "OVERLAYS_LIST=none" "PRINT_COUNT_ALWAYS=never" "eix" "--format" "<category>/<name> - <description>\n")
+    (process-file "env" nil '(t nil) nil "EIX_LIMIT=0" "OVERLAYS_LIST=none" "PRINT_COUNT_ALWAYS=never" "eix" "--format" "<category>/<name> - <description>\n")
     (goto-char (point-min))
     (while (search-forward " " nil t)
       (delete-char 1)
@@ -232,7 +232,7 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
     (helm-init-candidates-in-buffer
         'global
       (with-temp-buffer
-        (call-process "eix" nil t nil "--print-all-useflags")
+        (process-file "eix" nil t nil "--print-all-useflags")
         (buffer-string)))))
 
 (defcustom helm-system-packages-portage-use-actions
@@ -240,7 +240,7 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
      (lambda (elm)
        (switch-to-buffer helm-system-packages-buffer)
        (erase-buffer)
-       (apply #'call-process "euse" nil t nil `("--info" ,elm))
+       (apply #'process-file "euse" nil t nil `("--info" ,elm))
        (font-lock-add-keywords nil `((,elm . font-lock-variable-name-face)))
        (font-lock-mode 1)))
     ("Enable" .
@@ -269,7 +269,7 @@ The caller can pass the list of EXPLICIT packages to avoid re-computing it."
 (defun helm-system-packages-portage-use-transformer (use-flags)
   "Highlight enabled USE flags."
   (let ((local-uses (split-string (with-temp-buffer
-                                    (call-process "portageq" nil t nil "envvar" "USE")
+                                    (process-file "portageq" nil t nil "envvar" "USE")
                                     (buffer-string)))))
     (mapcar (lambda (use-flag)
               (propertize use-flag 'face

--- a/helm-system-packages-xbps.el
+++ b/helm-system-packages-xbps.el
@@ -31,6 +31,7 @@
 
 ;; Shut up byte compiler
 (declare-function eshell-interactive-process "esh-cmd.el")
+(defvar eshell-buffer-name)
 
 (defvar helm-system-packages-xbps-help-message
   "* Helm xbps

--- a/helm-system-packages-xbps.el
+++ b/helm-system-packages-xbps.el
@@ -271,16 +271,16 @@ If REVERSE is non-nil, list reverse dependencies instead."
                 " of "
                 (mapconcat 'identity (helm-marked-candidates) " "))))
     (helm-system-packages-show-packages
-     `((uninstalled
-        ,(mapconcat 'identity
-                    (mapcar (lambda (pkg)
-                              ;; Remove version numbers.
-                              (replace-regexp-in-string
-                               "[-<>][^-<>]+$" ""
-                               (helm-system-packages-call "xbps-query" nil "-R" arg pkg)))
-                            (helm-marked-candidates))
-                    "\n"))))
-    title))
+     `((uninstalled .
+                    ,(mapconcat 'identity
+                                (mapcar (lambda (pkg)
+                                          ;; Remove version numbers.
+                                          (replace-regexp-in-string
+                                           "[-<>][^-<>]+$" ""
+                                           (helm-system-packages-call "xbps-query" nil "-R" arg pkg)))
+                                        (helm-marked-candidates))
+                                "\n")))
+     title)))
 
 (defcustom helm-system-packages-xbps-actions
   '(("Show package(s)" . helm-system-packages-xbps-info)

--- a/helm-system-packages-xbps.el
+++ b/helm-system-packages-xbps.el
@@ -223,7 +223,7 @@ tested package to fall back on."
 (defun helm-system-packages-xbps-install (_)
   "Install marked candidates."
   (when helm-system-packages-xbps-auto-clean-cache
-    (let ((eshell-buffer-name helm-system-packages-eshell-buffer)) ; TODO: Use same as in main.
+    (let ((eshell-buffer-name (helm-system-packages-shell-name)))
       (eshell)
       (unless (eshell-interactive-process)
         (goto-char (point-max))

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -479,6 +479,8 @@ COMMAND will be run in the Eshell buffer `helm-system-packages-eshell-buffer'."
    (seq-filter (lambda (p) (assoc p (plist-get (helm-system-packages--cache-get) :display)))
                (helm-marked-candidates))))
 
+;; TODO: When all entries are filtered out by the transformer, it seems that
+;; bindings don't work (e.g. M-N to re-enable uninstalled packages).  Helm bug?
 (defun helm-system-packages-show-packages (package-alist &optional title)
   "Run a Helm session over the packages in PACKAGE-ALIST.
 The key of the alist is ignored and the package lists are considered as one
@@ -505,11 +507,12 @@ TITLE is the name of the Helm session."
                                  (make-string (- helm-system-packages-column-width (length name)) ? )
                                  "  <virtual package>"
                                  "\n"))))
-      (let ((ass (assq 'dependencies helm-system-packages--cache))
+      (let ((helm-system-packages--cache-current 'dependencies)
+            (ass (assq 'dependencies helm-system-packages--cache))
             (val (list :names buf :descriptions desc-res :title title)))
         (if ass
             (setcdr ass val)
-          (push val helm-system-packages--cache))
+          (push (cons 'dependencies val) helm-system-packages--cache))
         (helm-system-packages)))))
 
 (defun helm-system-packages-browse-url (urls)

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -58,6 +58,7 @@
 
 (require 'seq)
 (require 'tramp)
+(require 'tramp-sh)
 
 (defvar helm-system-packages-shell-buffer-name "helm-system-packages-eshell")
 (defvar helm-system-packages-eshell-buffer (concat "*" helm-system-packages-shell-buffer-name "*"))
@@ -129,8 +130,10 @@ This is only used for dependency display.")
 (declare-function eshell-send-input "esh-mode.el")
 (defvar eshell-buffer-name)
 (defvar helm-ff-transformer-show-only-basename)
+(declare-function helm-ff--create-tramp-name "helm-files.el")
 (declare-function helm-comp-read "helm-mode.el")
 (declare-function org-sort-entries "org.el")
+(declare-function helm-system-packages-refresh "helm-system-package.el")
 
 (defun helm-system-packages-toggle-explicit ()
   (interactive)

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -105,7 +105,7 @@ such as the package description."
   (let ((arg-list (append args (helm-marked-candidates))))
     (with-temp-buffer
       ;; We discard errors.
-      (apply #'call-process command nil t nil arg-list)
+      (apply #'process-file command nil t nil arg-list)
       (buffer-string))))
 
 (defun helm-system-packages-print (command &rest args)

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -57,6 +57,7 @@
 ;;   over the aforementioned category alists.
 
 (require 'seq)
+(require 'tramp)
 
 (defvar helm-system-packages-shell-buffer-name "helm-system-packages-eshell")
 (defvar helm-system-packages-eshell-buffer (concat "*" helm-system-packages-shell-buffer-name "*"))
@@ -70,6 +71,8 @@
 (defvar helm-system-packages--show-locals-p t)
 (defvar helm-system-packages--show-groups-p t)
 (defvar helm-system-packages--show-pinned-p t)
+
+;; TODO: Replace `mapcar' by `mapcan' when possible.
 
 ;; TODO: Possible optimization: turn into hash table, notably the display list.
 (defvar helm-system-packages--cache nil

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -446,16 +446,17 @@ In case of a hash table, one Helm source per package will be created."
 (defun helm-system-packages-shell-name ()
   "Return the name of the shell buffer associated with `default-directory'.
 The basename is defined by `helm-system-packages-shell-buffer-name'."
-  (let ((vec (tramp-dissect-file-name default-directory)))
-    (concat "*"
-            helm-system-packages-shell-buffer-name
-            (when (or (tramp-file-name-user vec) (tramp-file-name-host vec))
-              (concat " "
-                      (tramp-file-name-user vec)
-                      (and (tramp-file-name-host vec)
-                           "@")
-                      (tramp-file-name-host vec)))
-            "*")))
+  (concat "*"
+          helm-system-packages-shell-buffer-name
+          (when (tramp-tramp-file-p default-directory)
+            (let ((vec (tramp-dissect-file-name default-directory)))
+              (when (or (tramp-file-name-user vec) (tramp-file-name-host vec))
+                (concat " "
+                        (tramp-file-name-user vec)
+                        (and (tramp-file-name-host vec)
+                             "@")
+                        (tramp-file-name-host vec)))))
+          "*"))
 
 (defun helm-system-packages-call-as-root (command args packages)
   "Call COMMAND ARGS PACKAGES as root.

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -379,6 +379,21 @@ Otherwise display in `helm-system-packages-buffer'."
         (view-mode 1)))))
 (make-obsolete 'helm-system-packages-print 'helm-system-packages-show-information "1.9.0")
 
+(defun helm-system-packages-prefix-remote (file)
+  "Prefix FILE with path to remote connection.
+If local, return FILE unmodified."
+  (if (tramp-tramp-file-p default-directory)
+      (let ((v (tramp-dissect-file-name default-directory)))
+        (tramp-make-tramp-file-name
+         (tramp-file-name-method v)
+         (tramp-file-name-user v)
+         (tramp-file-name-domain v)
+         (tramp-file-name-host v)
+         (tramp-file-name-port v)
+         file
+         (tramp-file-name-hop v)))
+    file))
+
 (defun helm-system-packages-build-file-source (package files)
   "Build Helm file source for PACKAGE with FILES candidates.
 PACKAGES is a string and FILES is a list of strings."
@@ -387,7 +402,8 @@ PACKAGES is a string and FILES is a list of strings."
     :candidates files
     :candidate-transformer (lambda (files)
                              (let ((helm-ff-transformer-show-only-basename nil))
-                               (mapcar 'helm-ff-filter-candidate-one-by-one files)))
+                               (mapcar 'helm-ff-filter-candidate-one-by-one
+                                       (mapcar 'helm-system-packages-prefix-remote files))))
     :candidate-number-limit 'helm-ff-candidate-number-limit
     :persistent-action-if 'helm-find-files-persistent-action-if
     :keymap 'helm-find-files-map

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -383,15 +383,7 @@ Otherwise display in `helm-system-packages-buffer'."
   "Prefix FILE with path to remote connection.
 If local, return FILE unmodified."
   (if (tramp-tramp-file-p default-directory)
-      (let ((v (tramp-dissect-file-name default-directory)))
-        (tramp-make-tramp-file-name
-         (tramp-file-name-method v)
-         (tramp-file-name-user v)
-         (tramp-file-name-domain v)
-         (tramp-file-name-host v)
-         (tramp-file-name-port v)
-         file
-         (tramp-file-name-hop v)))
+      (helm-ff--create-tramp-name (concat default-directory file))
     file))
 
 (defun helm-system-packages-build-file-source (package files)

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -227,16 +227,16 @@ the window."
 See `helm-system-packages--cache-current'."
   (let ((host (or helm-system-packages--cache-current
                   (and (tramp-tramp-file-p default-directory)
-                       (tramp-file-name-host (car (tramp-list-connections))))
+                       (tramp-file-name-host (tramp-dissect-file-name default-directory)))
                   "")))
-    (alist-get host helm-system-packages--cache)))
+    (cdr (assoc host helm-system-packages--cache))))
 
 (defun helm-system-packages--cache-set (names descriptions display-list &optional title)
   "Set current cache entry.
 NAMES and DESCRIPTIONS are string buffers
 TITLE is a string, usually the name of the package manager."
   (let ((host (or (and (tramp-tramp-file-p default-directory)
-                       (tramp-file-name-host (car (tramp-list-connections))))
+                       (tramp-file-name-host (tramp-dissect-file-name default-directory)))
                   ""))
         (val (list :names names :descriptions descriptions :display display-list :title title)))
     (if (assoc host helm-system-packages--cache)
@@ -487,7 +487,7 @@ TITLE is the name of the Helm session."
       (message "No dependency list for package(s) %s" (mapconcat 'identity (helm-marked-candidates) " "))
     ;; TODO: Possible optimization: split-string + sort + del-dups + mapconcat instead of working on buffer.
     (let (desc-res
-          (descriptions (plist-get  (helm-system-packages--cache-get) :descriptions))
+          (descriptions (plist-get (helm-system-packages--cache-get) :descriptions))
           (buf (with-temp-buffer
                  (mapc 'insert (mapcar 'cdr package-alist))
                  (sort-lines nil (point-min) (point-max))
@@ -520,7 +520,7 @@ TITLE is the name of the Helm session."
   (let ((missing-deps
          (seq-remove (lambda (p)
                        (if (tramp-tramp-file-p default-directory)
-                           (tramp-find-executable (car (tramp-list-connections)) p nil)
+                           (tramp-find-executable (tramp-dissect-file-name default-directory) p nil)
                          (executable-find p)))
                      deps)))
     (when missing-deps
@@ -535,7 +535,7 @@ TITLE is the name of the Helm session."
   ;; hence the optional pair (PACKAGE-MANAGER EXECUTABLE).
   (let ((managers (seq-filter (lambda (p)
                                 (if (tramp-tramp-file-p default-directory)
-                                    (tramp-find-executable (car (tramp-list-connections)) (car p) nil)
+                                    (tramp-find-executable (tramp-dissect-file-name default-directory) (car p) nil)
                                   (executable-find (car p))))
                               '(("emerge" "portage") ("dpkg") ("pacman") ("xbps-query" "xbps")))))
     (if (not managers)

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -363,7 +363,7 @@ Return the result as a string."
 
 With prefix argument, insert the output at point.
 Otherwise display in `helm-system-packages-buffer'."
-  (let ((res (apply #'helm-system-packages-run command args)))
+  (let ((res (helm-system-packages-call command args)))
     (if (string= res "")
         (message "No result")
       (unless helm-current-prefix-arg

--- a/readme.org
+++ b/readme.org
@@ -3,7 +3,7 @@
 * Introduction
 
 Helm System Packages is an Emacs-based interface to the package manager of your
-operating system.
+operating system /and/ remote systems as well.
 
 Emacs' knowledge is not required: see the [[stand-alone][stand-alone]] folder for a version targeted at
 non-Emacs users.  Run the script and everything should be self-explanatory.  If
@@ -11,13 +11,14 @@ not then it's bug, please report it.
 
 Start ~helm-system-packages~ to list all available packages (with installed
 packages as well as dependencies displayed in their own respective face).
-Fuzzy-search, mark and execute the desired action over any set of packages:
+Fuzzy-search, mark and execute the desired action over any selections of
+packages:
 
 - Install.
 - Uninstall.
 - Display packages details (in Org Mode!) or insert details at point.
 - Find files owned by packages.
-- And much more.
+- And much more, including performing all the above over the network!
 
 Helm System Packages provides a uniform interface over the following package
 managers:
@@ -38,6 +39,10 @@ There is only one entry point: ~helm-system-packages~.
 Use the persistent action to view the details of the marked packages.
 
 Most actions can be called with a prefix argument to insert the result at point.
+
+If started from a remote TRAMP buffer (e.g. dired, Eshell or just any remote
+file), ~helm-system-packages~ automatically switches to the packages of the
+remote system.  The remove package manager can be different from the local one.
 
 ** Maintenance & other operations
 


### PR DESCRIPTION
This is a follow up on #12.

This makes it possible to run `helm-system-packages` remotely, even on systems running a different package manager.

I've tested pacman over TRAMP.  Seems to work like a charm.
I have made some breaking changes so I'm not sure if dpkg and portage still work.

Let me know if there is anything broken.
I'll merge in a week or so.

@dvzubarev, @thierryvolpiatto?