### PR TITLE
Fix helm min version requirement

### DIFF
--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -6,7 +6,7 @@
 ;; Author: Pierre Neidhardt <mail@ambrevar.xyz>
 ;; URL: https://github.com/emacs-helm/helm-system-packages
 ;; Version: 1.10.1
-;; Package-Requires: ((emacs "24.4") (helm "2.8.6") (seq "1.8"))
+;; Package-Requires: ((emacs "24.4") (helm "2.8.7") (seq "1.8"))
 ;; Keywords: helm, packages
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
helm-system-package uses :persistent-action-if which has been
introduced in helm 2.8.7.