### PR TITLE
removes quote desc-list on push

### DIFF
--- a/helm-system-packages-brew.el
+++ b/helm-system-packages-brew.el
@@ -120,7 +120,7 @@ Otherwise display in `helm-system-packages-buffer'."
                                        (alist-get 'options pkg-desc-alist) "\n")
              "\n\n"
              "* Caveats: " (alist-get 'caveats pkg-desc-alist) "\n"))
-      (push `(uninstalled (,pkg . ,str)) 'desc-list)
+      (push `(uninstalled (,pkg . ,str)) desc-list)
       (setq i (1+ i)))
     (helm-system-packages-show-information desc-list)))
 


### PR DESCRIPTION
I wanted to give it a try to this package and after calling `hellm-system-packages`, I selected a package to show it's info, I got`condition-case: Symbol’s function definition is void: \(setf\ quote\)`.

I believe there is no need to quote `desc-list`, is this right or am I missing something?