### PR TITLE
README: Update Voidlinux URL

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -122,6 +122,6 @@ We probably still need specific "info" actions to insert at point.
 Can we include as many filtered candidates as possible?
 
 * References
-- https://wiki.voidlinux.eu/Rosetta_stone
+- https://wiki.voidlinux.org/Rosetta_stone
 - https://wiki.archlinux.org/index.php/Pacman/Rosetta
 - https://github.com/jabranham/system-packages


### PR DESCRIPTION
The old link is dead and the website doesn't seem to be affiliated with Voidlinux anymore