### PR TITLE
Add ANSI colors to select Portage commands.

### DIFF
--- a/helm-system-packages-portage.el
+++ b/helm-system-packages-portage.el
@@ -143,10 +143,10 @@ If nil, then use `helm-system-packages-column-width'."
        (helm-system-packages-browse-url (split-string (helm-system-packages-run "eix" "--format" "<homepage>\n") "\n" t))))
     ("Find files" .
      (lambda (_)
-       (helm-system-packages-print "equery" "--no-color" "files")))
+       (helm-system-packages-print "equery" "files")))
     ("Show dependencies" .
      (lambda (_)
-       (helm-system-packages-print "equery" "--no-color" "depgraph")))
+       (helm-system-packages-print "equery" "depgraph")))
     ("Show reverse dependencies" .
      (lambda (_)
        (helm-system-packages-print "equery" "--no-color" "depends")))

--- a/helm-system-packages.el
+++ b/helm-system-packages.el
@@ -61,6 +61,7 @@
 (require 'tramp-sh)
 (require 'helm)
 (require 'cl-lib)
+(require 'ansi-color)
 
 (defvar helm-system-packages-shell-buffer-name "helm-system-packages-eshell")
 (defvar helm-system-packages-eshell-buffer (concat "*" helm-system-packages-shell-buffer-name "*"))
@@ -407,7 +408,8 @@ Otherwise display in `helm-system-packages-buffer'."
         (org-mode)
         ;; This is does not work for pacman which needs a specialized function.
         (setq res (replace-regexp-in-string "\\`.*: " "* " res))
-        (setq res (replace-regexp-in-string "\n\n.*: " "\n* " res)))
+        (setq res (replace-regexp-in-string "\n\n.*: " "\n* " res))
+        (setq res (ansi-color-apply res)))
       (save-excursion (insert res))
       (unless (or helm-current-prefix-arg helm-system-packages-editable-info-p)
         (view-mode 1)))))


### PR DESCRIPTION
For the following text, I will refer to the `helm-system-packages-portage-actions` by their shell command. Before this commit, the `genlop -qe` and `genlop -qi` commands outputted ANSI escape characters which were not colorized in the output buffer. Rather than adding the `--nocolor` argument for these actions, this pull request proposes that we accept ANSI color output these commands and that we colorize that output with `ansi-color-apply`. I also enabled ANSI color output for two other commands which produced visually pleasing color output.